### PR TITLE
IE 9 password inputs with size

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -20,7 +20,9 @@
 					<p><input type="url" name="url" id="url" placeholder="Insert url here" /></p>
 					<p><input type="search" name="search" id="search" placeholder="Search" /></p>
 					<p><textarea cols="50" rows="3" name="textarea" id="textarea" placeholder="Write your comments here"></textarea></p>
-					<p><input type="password" name="password" id="password" placeholder="Type password here" /></p>
+          <p><input type="password" name="password" id="password" placeholder="Type password here" /></p>
+          <p>Problem with password and size on IE 9</p>
+					<p><input type="password" name="passwordsize" id="passwordsize" size="55" placeholder="Type password here (size)" /></p>
 					
 					<div class="separator"></div>
 					

--- a/js/jquery.placeholder-enhanced.js
+++ b/js/jquery.placeholder-enhanced.js
@@ -95,9 +95,15 @@
 			else {
 				// get class from the original input if any (to keep any styling)
 				var inputCssClass = (e[0].className) ? ' ' + e[0].className : '';
+				var size = '';
+
+				// ie9 patch
+				if ( e[0].size && e[0].size > 0 ) {
+					size = 'size="' + e[0].size + "'";
+				}
 			
 				// create input with tabindex="-1" to skip tabbing
-				var pwdummy = $('<input type="text" class="' + c + inputCssClass + '" value="' + d + '" tabindex="-1" />');
+				var pwdummy = $('<input type="text" class="' + c + inputCssClass + '" value="' + d + '"' + size + ' tabindex="-1" />');
 				
 				// trigger password focus when focus is on text input
 				pwdummy.bind('focus.placeholder', function() {


### PR DESCRIPTION
Hello,

I stumbled across a bug with IE 9 and password placeholders. If the password inputs have a size set the placeholder input is created without that size and it causes the password input to be smaller (some weird IE default or maybe its determined by the css styling). Then when a user enters back into the password input it changes back to the original size which looks kind of strange :)

Great work on the library, it works great!

Thanks,

Lee
