### PR TITLE
fixed .val('') for native support

### DIFF
--- a/js/jquery.placeholder-enhanced.js
+++ b/js/jquery.placeholder-enhanced.js
@@ -83,7 +83,7 @@
         return el.value;
 
       // handle .val(''), .val(null), .val(undefined)
-      } else if (!arguments[0] && this.attr('placeholder')) {
+      } else if (!arguments[0] && el._placeholder) {
         this.attr('placeholder', el._placeholder);
       }
 


### PR DESCRIPTION
Fixed bug that prevents the .val('') to work in modern browsers
