### PR TITLE
Added better support for emptying forms

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -61,7 +61,7 @@
     // placeholder should appear
     $('#empty_btn').bind('click', function () {
       // supports .val(''), .val(null), .val(undefined)
-      $form.find('input:not([type="submit"]), textarea').val('');
+      $input.val('');
     });
   });
 </script>


### PR DESCRIPTION
Hi! I've revritten the val () function to handle multiple elements!

We are using this version on http://www.thecorner.com, to empty all the elements in a form with a simple

$form.find('input').val('');

Hope might come useful.
