### PR TITLE
Fix $.val()

### DIFF
--- a/js/jquery.placeholder-enhanced.js
+++ b/js/jquery.placeholder-enhanced.js
@@ -119,7 +119,12 @@
 
           // Handle .val(''), .val(null), .val(undefined)
           if (!args[0] && el.value !== placeholderTxt) {
-            el.value = $el.addClass(settings.cssClass).attr('placeholder');
+            if ($el.is(':focus')) {
+              //do not show the fake placeholder if the element already has focus
+              el.value = args[0];
+            } else {
+              el.value = $el.addClass(settings.cssClass).attr('placeholder');
+            }
 
           // Handle .val('value')
           } else if (args[0]) {
@@ -159,7 +164,7 @@
         if (settings && placeholderTxt && isValidNode(el)) {
 
           // Handle .val(''), .val(null), .val(undefined)
-          if (!args[0] && el.value !== placeholderTxt) {
+          if (!args[0] && el.value !== placeholderTxt && !$el.is(':focus')) {
 
             // Restore the placeholder
             $el.addClass(settings.cssClass).attr('placeholder', placeholderTxt);


### PR DESCRIPTION
Two fixes for the replacement of jQuery.val:
- `$('someQuery').val('someValue')` should return the jQuery selection even if it is empty, but it was returning undefined. This breaks chained calls.
- When an input is programmatically emptied while having the focus, it should not be put in placeholder mode. As it has focus, the user can type something in and it would be shown with placeholder style.

By the way, thanks for this plug-in, by the far the best of all solutions I have seen! :)
